### PR TITLE
chore: enable branch protection for `main` on delta repo

### DIFF
--- a/otterdog/EclipseConTutorial.jsonnet
+++ b/otterdog/EclipseConTutorial.jsonnet
@@ -115,6 +115,13 @@ orgs.newOrg('EclipseConTutorial') {
       workflows+: {
         default_workflow_permissions: "write",
       },
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          # lets set the required number of approvals to 0 to make changes later
+          # on easier for the purpose of this tutorial
+          required_approving_review_count: 0
+        }
+      ],
     },
     orgs.newRepo('test-repo-epsilon') {
       allow_merge_commit: true,


### PR DESCRIPTION
This PR enables branch protection rules on `main` branch for the [delta repo](https://github.com/VulnGame/VulnGame-EclipseCon-Delta)