### PR TITLE
chore: set default workflow permissions to read on `delta`

### DIFF
--- a/otterdog/EclipseConTutorial.jsonnet
+++ b/otterdog/EclipseConTutorial.jsonnet
@@ -120,7 +120,7 @@ orgs.newOrg('EclipseConTutorial') {
       template_repository: "EclipseConTutorial/test-repo-template",
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {


### PR DESCRIPTION
Lowers the default workflow permissions from `write` to `read` for the [delta repo](https://github.com/VulnGame/VulnGame-EclipseCon-Delta)